### PR TITLE
Default of .library parameter, and order of loadNamespace() and getNamespaceExports()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: import
 Type: Package
 Title: An Import Mechanism for R
-Version: 1.3.0
+Version: 1.3.0.9001
 Authors@R:
     c(person(given = "Stefan Milton",
              family = "Bache",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+
+Version 1.3.0.9xxx
+=============
+
+* The `import` package will now by default use the full current set of library
+  paths, i.e. the result of `.libPaths()`, while in versions up to and including
+  `1.3.0` this defaulted to use only the *first* entry in the library paths, i.e.
+  `.library=.libPaths()[1L]`.
+
+* The order of `loadNamespace()` and `getNamespaceExports()` has been changed in
+  `import::from()`. While this is intended to be a bug fix, it is possible that
+  it affects usage in situations where specificity about the library path is
+  important.
+
+
 Version 1.3.0
 =============
 

--- a/R/from.R
+++ b/R/from.R
@@ -57,7 +57,8 @@
 #'   \code{.into={environment()}} causes imports to be made into the current
 #'   environment; \code{.into=""} is an equivalent shorthand value.
 #' @param .library character specifying the library to use when importing from
-#'   packages. Defaults to the latest specified library.
+#'   packages. Defaults to the current set of library paths (note that the
+#'   default value was different in versions up to and including \code{1.3.0}).
 #' @param .directory character specifying the directory to use when importing
 #'   from modules. Defaults to the current working directory. If .from is a
 #'   module specified using an absolute path (i.e. starting with \code{/}),

--- a/R/from.R
+++ b/R/from.R
@@ -214,12 +214,12 @@ from <- function(.from, ..., .into = "imports",
   } else {
     # Load the package namespace, which is passed to the import calls.
     spec <- package_specs(.from)
-    all_objects <- getNamespaceExports(spec$pkg)
     pkg <- tryCatch(
       loadNamespace(spec$pkg, lib.loc = .library,
                     versionCheck = spec$version_check),
       error = function(e) stop(conditionMessage(e), call. = FALSE)
     )
+    all_objects <- getNamespaceExports(spec$pkg)
     pkg_name <- spec$pkg
   }
   # If .all parameter was specified, override with list of all objects

--- a/R/from.R
+++ b/R/from.R
@@ -99,7 +99,7 @@
 #'     }
 #' @md
 from <- function(.from, ..., .into = "imports",
-                 .library = .libPaths()[1L], .directory=".",
+                 .library = .libPaths(), .directory=".",
                  .all=(length(.except) > 0), .except=character(),
                  .chdir = TRUE, .character_only = FALSE, .S3 = FALSE)
 {

--- a/README.md
+++ b/README.md
@@ -113,11 +113,16 @@ section of the package vignette.
 
 ### Choosing where import looks for packages or modules
 
-The `import` package will by default only use the latest specified library
-(i.e. the result of `.libPaths()[1L]`). It is possible to specify a different
-library using the `.library` argument in any of the `import` functions.
-One import call can only use *one* library so there will not be ambiguity
-as to where imports come from.
+The `import` package will by default use the current set of library paths, i.e.
+the result of `.libPaths()`. It is, however, possible to specify a different set
+of library paths using the `.library` argument in any of the `import` functions,
+for example to import packages installed in a custom location, or to remove any
+ambiguity as to where imports come from.
+
+Note that in versions up to and including `1.3.0` this defaulted to use only the
+*first* entry in the library paths, i.e. `.library=.libPaths()[1L]`. We believe
+the new default is applicable in a broader set of circumstances, but if this
+change causes any issues, we would very much appreciate hearing about it.
 
 When importing from a module (.R file), the directory where `import` looks for
 the module script can be specified with the with `.directory` parameter. 

--- a/man/importfunctions.Rd
+++ b/man/importfunctions.Rd
@@ -58,7 +58,8 @@ environment value, rather than the name of an environment. Using
 environment; \code{.into=""} is an equivalent shorthand value.}
 
 \item{.library}{character specifying the library to use when importing from
-packages. Defaults to the latest specified library.}
+packages. Defaults to the current set of library paths (note that the
+default value was different in versions up to and including \code{1.3.0}).}
 
 \item{.directory}{character specifying the directory to use when importing
 from modules. Defaults to the current working directory. If .from is a

--- a/man/importfunctions.Rd
+++ b/man/importfunctions.Rd
@@ -10,7 +10,7 @@ from(
   .from,
   ...,
   .into = "imports",
-  .library = .libPaths()[1L],
+  .library = .libPaths(),
   .directory = ".",
   .all = (length(.except) > 0),
   .except = character(),

--- a/tests/test_import/test_from.R
+++ b/tests/test_import/test_from.R
@@ -176,7 +176,6 @@ test_that("Importing .into a symbol works w/ .character_only=TRUE", {
 })
 
 test_that("Imports from libraries NOT defined in .libPaths work", {
-  testthat::skip("Implementation of this fix has been reverted")
   tmp_install_dir <- tempdir()
   if (!file.exists("packageToTest_0.1.0.tar.gz")) {
     system("R CMD build packageToTest")
@@ -209,7 +208,6 @@ test_that("Functions named `get` in arbitrary environment on search path do not 
 })
 
 test_that("Functions named `get` exported from packages do not mask base::get", {
-  skip("Implementation of fix allowing custom .libPaths has been reverted")
   tmp_install_dir <- tempdir()
   library(packageToTest, lib.loc = tmp_install_dir)
   expect_true("get" %in% getNamespaceExports("packageToTest"))

--- a/vignettes/import.Rmd
+++ b/vignettes/import.Rmd
@@ -352,11 +352,16 @@ cause it to be sourced twice.
 
 ### Choosing where import looks for packages or modules
 
-The `import` package will by default only use the latest specified library
-(i.e. the result of `.libPaths()[1L]`). It is possible to specify a different
-library using the `.library` argument in any of the `import` functions.
-One import call can only use *one* library so there will not be ambiguity
-as to where imports come from.
+The `import` package will by default use the current set of library paths, i.e.
+the result of `.libPaths()`. It is, however, possible to specify a different set
+of library paths using the `.library` argument in any of the `import` functions,
+for example to import packages installed in a custom location, or to remove any
+ambiguity as to where imports come from.
+
+Note that in versions up to and including `1.3.0` this defaulted to use only the
+*first* entry in the library paths, i.e. `.library=.libPaths()[1L]`. We believe
+the new default is applicable in a broader set of circumstances, but if this
+change causes any issues, we would very much appreciate hearing about it.
 
 When importing from a module (.R file), the directory where `import` looks for
 the module script can be specified with the with `.directory` parameter. 


### PR DESCRIPTION
Reimplement (revert the reversion of) switching the order of `loadNamespace()` and `getNamespaceExports()`, followed by the change of default value of `.library` parameter to `.libPaths(), which is necessary for things to work correctly with the new order of operation (previous order resulted in `.libPaths()` being used implicitly, even though the default value was `.libPaths()[1L]`. The final commit documents the change and bumps the version.

See #56 for a detailed discussion.