### PR TITLE
Hotfix for #86

### DIFF
--- a/R/S3.R
+++ b/R/S3.R
@@ -29,7 +29,7 @@ register_s3_method <- function(x, env){
 
   parts <- unlist(strsplit(x, split=".", fixed=TRUE))
   generic <- parts[1]
-  class <- paste(parts[-1], sep=".")
+  class <- paste0(parts[-1], collapse=".")
 
   registerS3method(generic, class, method, env)
 

--- a/tests/test_import/module_S3.R
+++ b/tests/test_import/module_S3.R
@@ -16,3 +16,8 @@ test_fun.numeric <- function(x){
 print.test_class <- function(x){
   print(as.character(x))
 }
+
+# a method for class with dot in name
+test_fun.data.frame = function(x){
+    structure("data.frame", class = "test_class")
+    }

--- a/tests/test_import/test_S3.R
+++ b/tests/test_import/test_S3.R
@@ -29,6 +29,7 @@ test_that("S3 methods are registered", {
   expect_silent( import::from("module_S3.R", "test_fun", .S3=TRUE) )
   expect_identical( test_fun(1), structure("numeric", class="test_class") )
   expect_identical( test_fun("1"), structure("character", class="test_class") )
+  expect_identical( test_fun(data.frame()), structure("data.frame", class="test_class"))
   expect_output( print(test_fun(1)), "numeric" )
   expect_output( print(test_fun("OK")), "character" )
   cleanup_environment()


### PR DESCRIPTION
This fixes issues of not being able to import classes with dots in their name.

This was actually a bug where `sep` instead of `collapse` was used in a vector.

The assumption that the method can't have dot in name remains. Possible fix for that would include looking around for imported generics with dot in name and registering methods for such generics.

In the meantime, there is this hotfix.