### PR TITLE
Fix #96

### DIFF
--- a/R/safe_assign.R
+++ b/R/safe_assign.R
@@ -16,7 +16,8 @@ safe_assign <- function(x, value, pos = -1, envir = as.environment(pos), inherit
 {
   if (x %in% ls(envir, all.names = TRUE) &&
      !identical(environment(envir[[x]]), environment(value)))
-    stop("Cannot assign name to different value in the given environment. Name already in use.",
+      stop(sprintf("Cannot assign name `%s` to different value in the given environment. Name already in use.",
+                   x),
          call. = FALSE)
 
   assign(x, value, pos, envir, inherits)

--- a/tests/test_import/test_from.R
+++ b/tests/test_import/test_from.R
@@ -36,6 +36,14 @@ test_that("Imports from modules work", {
   cleanup_environment()
 })
 
+test_that("Conflicting imports throw error containing conflicting name", {
+    expect_error ( fun1() )
+    expect_silent( import::from(module_base.R, fun1) )
+    expect_error( import::from(module_hidden_objects.R, fun1) )
+    expect_error( import::from(module_hidden_objects.R, fun1), ".*fun1.*" )
+    cleanup_environment()
+})
+
 test_that("Subsequent imports from modules work", {
   expect_error ( fun1() )
   expect_error ( fun7() )

--- a/tests/test_import/test_from.R
+++ b/tests/test_import/test_from.R
@@ -39,8 +39,8 @@ test_that("Imports from modules work", {
 test_that("Conflicting imports throw error containing conflicting name", {
     expect_error ( fun1() )
     expect_silent( import::from(module_base.R, fun1) )
-    expect_error( import::from(module_hidden_objects.R, fun1) )
-    expect_error( import::from(module_hidden_objects.R, fun1), ".*fun1.*" )
+    expect_error ( import::from(module_hidden_objects.R, fun1) )
+    expect_error ( import::from(module_hidden_objects.R, fun1), ".*fun1.*" )
     cleanup_environment()
 })
 


### PR DESCRIPTION
This PR:

1. Changes safe_assign so that, when there are conflicting imports, the error message shows the conflicting name.
2. Adds a test for this.

I added two tests: the first one tests that importing a conflicting name errors (satisfied by the current behavior, I did not find a current test for this) and the second checks that the error message contains the conflicting name.

This would fix close #96 