### PR TITLE
Point package website to github.io

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Alternative mechanism for importing objects from packages
     Furthermore the imported objects are not placed in the current environment.
 License: MIT + file LICENSE
 ByteCompile: TRUE
-URL: https://import.rticulate.org/, https://github.com/rticulate/import
+URL: https://rticulate.github.io/import/, https://github.com/rticulate/import
 BugReports: https://github.com/rticulate/import/issues
 Suggests:
     knitr,

--- a/R/from.R
+++ b/R/from.R
@@ -92,7 +92,7 @@
 #'
 #' @seealso
 #'   Helpful links:
-#'    * [https://import.rticulate.org](https://import.rticulate.org)
+#'    * [https://rticulate.github.io/import](https://rticulate.github.io/import)
 #'    * [https://github.com/rticulate/import](https://github.com/rticulate/import)
 #'    * [https://github.com/rticulate/import/issues](https://github.com/rticulate/import/issues)
 #'

--- a/R/import.R
+++ b/R/import.R
@@ -19,7 +19,7 @@
 #'   [`here`].
 #'
 #'   Helpful links:
-#'   * [https://import.rticulate.org](https://import.rticulate.org)
+#'   * [https://rticulate.github.io/import](https://rticulate.github.io/import)
 #'   * [https://github.com/rticulate/import](https://github.com/rticulate/import)
 #'   * [https://github.com/rticulate/import/issues](https://github.com/rticulate/import/issues)
 #'

--- a/README.Rmd
+++ b/README.Rmd
@@ -2,7 +2,7 @@
 output: github_document
 ---
 
-# import <a href="https://import.rticulate.org"><img src="man/figures/logo.png" align="right" height="138" /></a>
+# import <a href="https://rticulate.github.io/import"><img src="man/figures/logo.png" align="right" height="138" /></a>
 
 <!-- badges: start -->
 [![CRAN status](https://www.r-pkg.org/badges/version/import)](https://CRAN.R-project.org/package=import)
@@ -14,8 +14,8 @@ output: github_document
 
 The import package is intended to simplify the way in which functions from
 external packages or modules are made available for use in R scripts. Learn more
-on the [package website](https://import.rticulate.org/), by reading
-[`vignette("import")`](https://import.rticulate.org/articles/import.html), or
+on the [package website](https://rticulate.github.io/import/), by reading
+[`vignette("import")`](https://rticulate.github.io/import/articles/import.html), or
 using the help (`?import::from`).
 
 ## Introduction
@@ -37,7 +37,7 @@ import::from(Hmisc, impute, nomiss)
 ```
 
 For more on the motivation behind the package, see 
-[vignette("import")](https://import.rticulate.org/articles/import.html)
+[vignette("import")](https://rticulate.github.io/import/articles/import.html)
 
 
 ## Installation
@@ -100,7 +100,7 @@ _not_ explicitly omitting, and sets the `.all` parameter to `TRUE`. You can
 still override this in exceptional cases, but you seldom need to.
 
 These and other examples are discussed in more detail in the 
-[Importing from Packages](https://import.rticulate.org/articles/import.html#importing-from-packages)
+[Importing from Packages](https://rticulate.github.io/import/articles/import.html#importing-from-packages)
 section of the package vignette.
 
 ### Importing Functions from "Module" Scripts
@@ -123,7 +123,7 @@ import::from(sequence_module.R, fib=fibonacci, .except="square")
 ```
 
 These and other examples are discussed in more detail in the 
-[Importing from Modules](https://import.rticulate.org/articles/import.html#importing-functions-from-module-scripts) 
+[Importing from Modules](https://rticulate.github.io/import/articles/import.html#importing-functions-from-module-scripts) 
 section of the package vignette.
 
 ### Choosing where import looks for packages or modules
@@ -185,7 +185,7 @@ import::from(module_name, foo, bar, .character_only=TRUE)
 ```
 
 The `.character_only` parameter is covered in more detail in the 
-[Advanced Usage](https://import.rticulate.org/articles/import.html#advanced-usage) 
+[Advanced Usage](https://rticulate.github.io/import/articles/import.html#advanced-usage) 
 section of the package vignette, which also describes how you can import from
 module scripts stored online with the help of the `pins` package, or achieve
 python-like imports with the help of `{}` notation for environments in the

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# import <a href="https://import.rticulate.org"><img src="man/figures/logo.png" align="right" height="138" /></a>
+# import <a href="https://rticulate.github.io/import"><img src="man/figures/logo.png" align="right" height="138" /></a>
 
 <!-- badges: start -->
 
@@ -16,8 +16,8 @@ status](https://github.com/rticulate/import/workflows/R-CMD-check/badge.svg)](ht
 The import package is intended to simplify the way in which functions
 from external packages or modules are made available for use in R
 scripts. Learn more on the [package
-website](https://import.rticulate.org/), by reading
-[`vignette("import")`](https://import.rticulate.org/articles/import.html),
+website](https://rticulate.github.io/import/), by reading
+[`vignette("import")`](https://rticulate.github.io/import/articles/import.html),
 or using the help (`?import::from`).
 
 ## Introduction
@@ -40,7 +40,7 @@ import::from(Hmisc, impute, nomiss)
 ```
 
 For more on the motivation behind the package, see
-[vignette(“import”)](https://import.rticulate.org/articles/import.html)
+[vignette(“import”)](https://rticulate.github.io/import/articles/import.html)
 
 ## Installation
 
@@ -104,7 +104,7 @@ but you seldom need to.
 
 These and other examples are discussed in more detail in the [Importing
 from
-Packages](https://import.rticulate.org/articles/import.html#importing-from-packages)
+Packages](https://rticulate.github.io/import/articles/import.html#importing-from-packages)
 section of the package vignette.
 
 ### Importing Functions from “Module” Scripts
@@ -129,7 +129,7 @@ import::from(sequence_module.R, fib=fibonacci, .except="square")
 
 These and other examples are discussed in more detail in the [Importing
 from
-Modules](https://import.rticulate.org/articles/import.html#importing-functions-from-module-scripts)
+Modules](https://rticulate.github.io/import/articles/import.html#importing-functions-from-module-scripts)
 section of the package vignette.
 
 ### Choosing where import looks for packages or modules
@@ -196,7 +196,7 @@ import::from(module_name, foo, bar, .character_only=TRUE)
 
 The `.character_only` parameter is covered in more detail in the
 [Advanced
-Usage](https://import.rticulate.org/articles/import.html#advanced-usage)
+Usage](https://rticulate.github.io/import/articles/import.html#advanced-usage)
 section of the package vignette, which also describes how you can import
 from module scripts stored online with the help of the `pins` package,
 or achieve python-like imports with the help of `{}` notation for

--- a/man/import.Rd
+++ b/man/import.Rd
@@ -27,7 +27,7 @@ For usage instructions and examples, see \code{\link{from}}, \code{\link{into}},
 
 Helpful links:
 \itemize{
-\item \url{https://import.rticulate.org}
+\item \url{https://rticulate.github.io/import}
 \item \url{https://github.com/rticulate/import}
 \item \url{https://github.com/rticulate/import/issues}
 }

--- a/man/importfunctions.Rd
+++ b/man/importfunctions.Rd
@@ -152,7 +152,7 @@ import::into("imports:parallel", makeCluster, parLapply, .from = parallel)
 \seealso{
 Helpful links:
 \itemize{
-\item \url{https://import.rticulate.org}
+\item \url{https://rticulate.github.io/import}
 \item \url{https://github.com/rticulate/import}
 \item \url{https://github.com/rticulate/import/issues}
 }

--- a/vignettes/import.Rmd
+++ b/vignettes/import.Rmd
@@ -12,8 +12,8 @@ editor_options:
 ---
 
 * This version: May, 2022
-* Latest version at: https://import.rticulate.org/articles/import.html
-* A briefer intro at: https://import.rticulate.org/
+* Latest version at: https://rticulate.github.io/import/articles/import.html
+* A briefer intro at: https://rticulate.github.io/import/
 
 # Introduction
 


### PR DESCRIPTION
All I did was do a find and replace (`import.rticulate.org` -> `rticulate.github.io/import` ), local `devtools::check()` and github actions in my fork are passing, I hope that is all that is needed.

Closes #102.